### PR TITLE
Add support for running multiple clusters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .terraform*
 .certs
-kubeconfig
+kubeconfig*
 *.tfstate*

--- a/README.md
+++ b/README.md
@@ -69,3 +69,34 @@ https://argocd.local-cluster.dev
 
 HTTPBin:
 https://httpbin.local-cluster.dev
+
+# Multiple Clusters
+If you want to run multiple clusters with this module you'll want the clusters
+to have different CIDR ranges.   To do this you can use the variables
+`cidr_start` and `cidr_end` and make sure they don't conflict.  You will also
+want to make sure you generate different `kubeconfig` paths for each.
+
+A configuration could look something like this:
+
+```
+module "local-cluster" {
+  source           = "../"
+  certs_path       = "./.certs"
+  k8s_config_path  = "./kubeconfig-cluster1"
+  k8s_cluster_name = "example-kind-cluster"
+  base_domain      = "local-cluster.dev"
+  cidr_start       = 200
+  cidr_end         = 205
+}
+
+module "best-cluster" {
+  source           = "../"
+  certs_path       = "./.certs"
+  k8s_config_path  = "./kubeconfig-cluster2"
+  k8s_cluster_name = "example-kind-cluster2"
+  base_domain      = "best-cluster.dev"
+  cidr_start       = 206
+  cidr_end         = 210
+}
+
+```

--- a/example-usage/main.tf
+++ b/example-usage/main.tf
@@ -1,7 +1,19 @@
 module "local-cluster" {
   source           = "../"
   certs_path       = "./.certs"
-  k8s_config_path  = "./kubeconfig"
+  k8s_config_path  = "./kubeconfig-cluster1"
   k8s_cluster_name = "example-kind-cluster"
   base_domain      = "local-cluster.dev"
+  cidr_start       = 200
+  cidr_end         = 205
+}
+
+module "best-cluster" {
+  source           = "../"
+  certs_path       = "./.certs"
+  k8s_config_path  = "./kubeconfig-cluster2"
+  k8s_cluster_name = "example-kind-cluster2"
+  base_domain      = "best-cluster.dev"
+  cidr_start       = 206
+  cidr_end         = 210
 }

--- a/example-usage/main.tf
+++ b/example-usage/main.tf
@@ -1,7 +1,7 @@
 module "local-cluster" {
   source           = "../"
   certs_path       = "./.certs"
-  k8s_config_path  = "./kubeconfig-cluster1"
+  k8s_config_path  = "./kubeconfig"
   k8s_cluster_name = "example-kind-cluster"
   base_domain      = "local-cluster.dev"
 }

--- a/example-usage/main.tf
+++ b/example-usage/main.tf
@@ -4,16 +4,4 @@ module "local-cluster" {
   k8s_config_path  = "./kubeconfig-cluster1"
   k8s_cluster_name = "example-kind-cluster"
   base_domain      = "local-cluster.dev"
-  cidr_start       = 200
-  cidr_end         = 205
-}
-
-module "best-cluster" {
-  source           = "../"
-  certs_path       = "./.certs"
-  k8s_config_path  = "./kubeconfig-cluster2"
-  k8s_cluster_name = "example-kind-cluster2"
-  base_domain      = "best-cluster.dev"
-  cidr_start       = 206
-  cidr_end         = 210
 }

--- a/kind.tf
+++ b/kind.tf
@@ -31,6 +31,9 @@ resource "kind_cluster" "default" {
         EOF
       ]
 
+      /* Port mappings are not necessary because we have an actual LoadBalancer
+      with an external IP.   This is only necessary if you need to expose host
+      ports directly and have them forwarded to the cluster
       extra_port_mappings {
         container_port = 80
         host_port      = 80
@@ -40,6 +43,7 @@ resource "kind_cluster" "default" {
         container_port = 443
         host_port      = 443
       }
+      */
       /* Mount the self-signed cert into the node so it can communicate with
       ingresses */
       extra_mounts {

--- a/metal_lb.tf
+++ b/metal_lb.tf
@@ -82,7 +82,7 @@ metadata:
   namespace: ${local.metal_lb_namespace}
 spec:
   addresses:
-  - ${cidrhost(local.docker_subnet, 200)}-${cidrhost(local.docker_subnet, 250)}
+  - ${cidrhost(local.docker_subnet, var.cidr_start)}-${cidrhost(local.docker_subnet, var.cidr_end)}
 EOF
 
   depends_on = [helm_release.metal_lb]

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,14 @@ variable "enable_httpbin" {
   default     = true
 }
 
+variable "cidr_start" {
+  description = "The start for the CIDR that is used for the loadbalancer"
+  type        = number
+  default     = 200
+}
+
+variable "cidr_end" {
+  description = "The end for the CIDR that is used for the loadbalancer"
+  type        = number
+  default     = 210
+}


### PR DESCRIPTION
This module needs to be usable across multiple projects and having the ability to spawn non-conclicting clusters will enable that.