### PR TITLE
Trow certs didn't work because of wrong path

### DIFF
--- a/kind.tf
+++ b/kind.tf
@@ -1,6 +1,6 @@
 locals {
   containerd_config_path = "/etc/containerd/certs.d/"
-  root_cert_path         = "${var.certs_path}/.certs/rootCA.pem"
+  root_cert_path         = "${var.certs_path}/rootCA.pem"
 }
 
 resource "kind_cluster" "default" {


### PR DESCRIPTION
I had left a `.certs` on the path and this was making the path invalid which meant we couldn't communicate with trow from within the cluster.