### PR TITLE
Add support for additional namespaces and certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,25 @@ module "best-cluster" {
   cidr_start       = 206
   cidr_end         = 210
 }
+```
+
+# Namespaces
+If you want to provision some additional namespaces to make sure they are
+ready to be used by helm/kustomize/etc you can pass `namespaces` variable as a
+list.
+
+```hcl
+namespaces = [
+  "foo",
+  "bar",
+]
+```
+
+# TLS certs
+If you want additonal certificates generated you can provide a map of namespaces
+and a list of domains you want generated for them with `additional_dns_names`
+variable:
 
 ```
+```
+

--- a/README.md
+++ b/README.md
@@ -118,9 +118,17 @@ namespaces = [
 
 # TLS certs
 If you want additonal certificates generated you can provide a map of namespaces
-and a list of domains you want generated for them with `additional_dns_names`
+and a list of domains you want generated for them with `additional_certs`
 variable:
 
-```
+```hcl
+additional_certs = {
+  "foo": [
+    "foo.dev"
+  ],
+  "bar": [
+    "bar.dev"
+  ]
+}
 ```
 

--- a/additional_certs.tf
+++ b/additional_certs.tf
@@ -1,0 +1,12 @@
+module "additional_tls" {
+  for_each  = var.additional_certs
+  source    = "./modules/tls-cert"
+  namespace = each.key
+  dns_names = each.value
+  certs_path = var.certs_path
+
+  depends_on = [
+    kind_cluster.default,
+    helm_release.cert_manager,
+  ]
+}

--- a/additional_certs.tf
+++ b/additional_certs.tf
@@ -1,8 +1,8 @@
 module "additional_tls" {
-  for_each  = var.additional_certs
-  source    = "./modules/tls-cert"
-  namespace = each.key
-  dns_names = each.value
+  for_each   = var.additional_certs
+  source     = "./modules/tls-cert"
+  namespace  = each.key
+  dns_names  = each.value
   certs_path = var.certs_path
 
   depends_on = [

--- a/kind.tf
+++ b/kind.tf
@@ -77,3 +77,16 @@ resource "kind_cluster" "default" {
     }
   }
 }
+
+resource "kubectl_manifest" "additional_namespaces" {
+  for_each  = toset(var.namespaces)
+  yaml_body = <<YAML
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${each.value}
+YAML
+  depends_on = [
+    kind_cluster.default,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,15 @@ variable "cidr_end" {
   type        = number
   default     = 210
 }
+
+variable "namespaces" {
+  description = "The additional namespaces you want created"
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_certs" {
+  description = "The additional TLS certs you want created. Key is namespace, value is a list of DNS names"
+  type        = map(list(string))
+  default     = {}
+}


### PR DESCRIPTION
When provisioning the local cluster you may want to spin up some namespaces or additional certs without having to write a bunch of extra manifests.  This provides the tooling to do it.